### PR TITLE
fix: use same glob for oci registry upload and fix OCI issue

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -65,5 +65,5 @@ jobs:
                           --destination . \
                           --version ${{ github.ref_name }} \
                           --app-version ${{ github.ref_name }}
-          devbox run  -- echo "${GITHUB_TOKEN}" |  helm registry login ghcr.io --username ${{ github.actor }} --password-stdin &&  helm push vgpu-token-operator-chart-${{ github.ref_name }}.tgz  oci://ghcr.io/nutanix-cloud-native/vgpu-token-operator-charts
+          devbox run  -- echo "${GITHUB_TOKEN}" |  helm registry login ghcr.io --username ${{ github.actor }} --password-stdin &&  helm push vgpu-token-operator-*.tgz  oci://ghcr.io/nutanix-cloud-native/vgpu-token-operator-charts
           devbox run -- gh release upload ${{ github.ref_name }} vgpu-token-operator-*.tgz

--- a/charts/vgpu-token-operator/templates/_helpers.tpl
+++ b/charts/vgpu-token-operator/templates/_helpers.tpl
@@ -17,9 +17,6 @@
 {{- if .Chart.AppVersion -}}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Chart.Version }}
-helm.sh/chart: {{ .Chart.Version | quote }}
-{{- end }}
 app.kubernetes.io/name: {{ include "chart.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
**What problem does this PR solve?**:
-  fixes the upload again by using the same glob that is used to upload the artifact to the release 
- removes `Chart.Version` which is problematic w/ flux + OCI configuration

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
